### PR TITLE
Switch RFID hash representation for better consistency

### DIFF
--- a/rfidDoor/Door.py
+++ b/rfidDoor/Door.py
@@ -75,6 +75,12 @@ class Door(object):
       #removing whitespace characters coming from rdif reader
       x = rcv[3:11]
       self.log.info(str(x))
+      # Convert hex to 32-bit, big endian binary representation
+      x = bytes(bytearray(
+        int(x[0:1], 16),
+        int(x[2:3], 16),
+        int(x[4:5], 16),
+        int(x[6:7], 16)))
       #check db for user
       # This is the part swapped in
       if self.door_connection.check_request(x):

--- a/rfidLock/MemberDatabase.py
+++ b/rfidLock/MemberDatabase.py
@@ -2,7 +2,6 @@
 # There are certain
 
 import hashlib
-import pdb
 from base64 import b64encode
 from contextlib import closing
 from datetime import datetime
@@ -109,13 +108,10 @@ class MemberDatabase(object):
     """
     Uses the member's RFID data to check whether they are a current member.
     """
-    #pdb.set_trace()
     with closing(self.db.cursor()) as cur:
       cur.execute(self.have_current_query, (MemberDatabase.hash(card_data), datetime.now()))
       result = cur.fetchone()[0]
       self.db.commit()
-      #pdb.set_trace()
-      print result
       return result > 0
   def list(self):
     """Retrieves a list of all members and former members"""


### PR DESCRIPTION
In order to once and for all fix tag value representation problems the 32-bit big-endian binary representation of the number printed on the RFID tag should be used for hashing. Hashing the hexadecimal string representation of that number left ambiguity between using capital(A..F) and lowercase(a..f) hex letters. This should also make input from decimal format somewhat simpler as it will not require re-encoding to hexadecimal before hashing.

I suspect the capital-lowercase ambiguity may have been the reason that @jonathan46000 's RFID tag worked while mine and @Ranthalion 's did not.

As a quick clean-up, pdb usage is also removed.

Unfortunately, this will require re-entering hashes into the database once more.