### PR TITLE
setting up some events and listeners to fire email notifications

### DIFF
--- a/webCode/membership/app/Console/Commands/RevokeMembers.php
+++ b/webCode/membership/app/Console/Commands/RevokeMembers.php
@@ -20,14 +20,16 @@ class Revoked extends Command
      */
     protected $description = 'Revoke membership for members without a payment in the previous 60 days.';
 
+    protected $paymentImporter
     /**
      * Create a new command instance.
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(PaymentImporter $importer)
     {
         parent::__construct();
+        $this->paymentImporter = $importer;
     }
 
     /**
@@ -38,5 +40,6 @@ class Revoked extends Command
     public function handle()
     {
         //TODO: [ML] Revoke membership and send email
+        $this->paymentImporter->revokeMembers();
     }
 }

--- a/webCode/membership/app/Events/MemberApproachingRevokation.php
+++ b/webCode/membership/app/Events/MemberApproachingRevokation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+use App\Models\Member;
+
+class MemberApproachingRevokation
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public $member;
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Member $member)
+    {
+        $this->member = $member;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/webCode/membership/app/Events/MemberReinstated.php
+++ b/webCode/membership/app/Events/MemberReinstated.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+use App\Models\Member;
+
+class MemberReinstated
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public $member;
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Member $member)
+    {
+        $this->member = $member;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/webCode/membership/app/Events/MemberRevoked.php
+++ b/webCode/membership/app/Events/MemberRevoked.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+use App\Models\Member;
+
+class MemberRevoked
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public $member;
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Member $member)
+    {
+        $this->member = $member;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/webCode/membership/app/Http/Controllers/MemberController.php
+++ b/webCode/membership/app/Http/Controllers/MemberController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Request;
 use App\Http\Requests\UpdateKey;
 use App\Http\Requests\StoreMember;
 use App\Http\Requests\UpdateMember;
+use App\Events\MemberRevoked;
+use App\Events\MemberReinstated;
 use App\Models\Member;
 use App\Models\MemberTier;
 use App\Models\PaymentProvider;
@@ -187,6 +189,8 @@ class MemberController extends Controller
         $member->member_status_id = 2;
         $member->save();
 
+        event(new MemberRevoked($member));
+
         Session::flash('message', $member->name.' has been revoked.');
         return redirect('members');
     }
@@ -203,6 +207,8 @@ class MemberController extends Controller
         $member = Member::find($id);
         $member->member_status_id = 1;
         $member->save();
+
+        event(new MemberReinstated($member));
 
         Session::flash('message', $member->name.' has been restored.');
         return redirect('members/inactive');

--- a/webCode/membership/app/Listeners/NotifyPendingRevokation.php
+++ b/webCode/membership/app/Listeners/NotifyPendingRevokation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MemberApproachingRevokation;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+use Illuminate\Support\Facades\Mail;
+use App\Mail\PendingRevokation;
+
+class NotifyPendingRevokation
+{
+    /**
+     * Handle the event.
+     *
+     * @param  MemberApproachingRevokation  $event
+     * @return void
+     */
+    public function handle(MemberApproachingRevokation $event)
+    {
+        Mail::to($event->member->email)->bcc("Michael.Lane@hackrva.org")->send(new PendingRevokation($event->member));
+    }
+}

--- a/webCode/membership/app/Listeners/NotifyRevokedMember.php
+++ b/webCode/membership/app/Listeners/NotifyRevokedMember.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MemberRevoked;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+use App\Mail\RevokeMember;
+use Illuminate\Support\Facades\Mail;
+
+
+class NotifyRevokedMember
+{
+    /**
+     * Handle the event.
+     *
+     * @param  MemberRevoked  $event
+     * @return void
+     */
+    public function handle(MemberRevoked $event)
+    {
+        Mail::to($event->member->email)->bcc("Michael.Lane@hackrva.org")->send(new RevokeMember($event->member));
+    }
+}

--- a/webCode/membership/app/Listeners/ReinstateMember.php
+++ b/webCode/membership/app/Listeners/ReinstateMember.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MemberReinstated;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+use Illuminate\Support\Facades\Mail;
+use App\Mail\RenewMembership;
+
+class ReinstateMember
+{
+    /**
+     * Handle the event.
+     *
+     * @param  MemberReinstated  $event
+     * @return void
+     */
+    public function handle(MemberReinstated $event)
+    {
+        Mail::to($event->member->email)->bcc("Michael.Lane@hackrva.org")->send(new RenewMembership($event->member));
+    }
+}

--- a/webCode/membership/app/Listeners/WelcomeMailer.php
+++ b/webCode/membership/app/Listeners/WelcomeMailer.php
@@ -13,16 +13,6 @@ use Illuminate\Support\Facades\Mail;
 class WelcomeMailer implements ShouldQueue
 {
     /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Handle the event.
      *
      * @param  MemberAdded  $event

--- a/webCode/membership/app/Mail/RevokeMember.php
+++ b/webCode/membership/app/Mail/RevokeMember.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 use App\Models\Member;
 
-class RenewMembership extends Mailable
+class RevokeMember extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 
@@ -32,16 +32,8 @@ class RenewMembership extends Mailable
      */
     public function build()
     {
-        if ($this->member->level == "Premium")
-        {
-          return $this->view('emails.renewmembershipPremium')
-              ->text('emails.renewmembershipPremium_plain');
-        }
-        else
-        {
-          return $this->view('emails.renewmembershipStandard')
-              ->text('emails.renewmembershipStandard_plain');
-        }
-
+        return $this->from('info@hackrva.org')
+            ->view('emails.RevokeMembership')
+            ->text('emails.RevokeMembership_plain');
     }
 }

--- a/webCode/membership/app/Providers/EventServiceProvider.php
+++ b/webCode/membership/app/Providers/EventServiceProvider.php
@@ -18,6 +18,15 @@ class EventServiceProvider extends ServiceProvider
             'App\Listeners\SlackInvite',
             'App\Listeners\MailSubscription',
         ],
+        'App\Events\MemberApproachingRevokation' => [
+            'App\Listeners\NotifyPendingREvokation'
+        ],
+        'App\Events\MemberRevoked' => [
+            'App\Listeners\NotifyRevokedMember'
+        ],
+        'App\Events\MemberReinstated' => [
+            'App\Listeners\ReinstateMember'
+        ]
     ];
 
     /**


### PR DESCRIPTION
It looks like some of the notifications are already going out.
I set these up to get triggered when we call an event.

Having some issues setting up the mail integration locally.
Can you test this when you get a chance?

We can add another listener on `MemberRevoked` in webCode/membership/app/Providers/EventServiceProvider.php to actually revoke the membership 

... and I guess we will need to add a command to run on schedule in `kernel.php`

#26 